### PR TITLE
Remove deprecated Google Sign in methods

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)
-    implementation(libs.play.services.auth)
     implementation(libs.picasso)
     implementation(libs.credentials)
     implementation(libs.credentials.play.services)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,5 +54,8 @@ dependencies {
     implementation(libs.firebase.auth.ktx)
     implementation(libs.play.services.auth)
     implementation(libs.picasso)
+    implementation(libs.credentials)
+    implementation(libs.credentials.play.services)
+    implementation(libs.googleid)
 
 }

--- a/app/src/main/java/sayan/apps/numplex/FeedbackFragment.kt
+++ b/app/src/main/java/sayan/apps/numplex/FeedbackFragment.kt
@@ -11,7 +11,7 @@ import android.widget.EditText
 import android.widget.RatingBar
 import android.widget.Toast
 import androidx.fragment.app.Fragment
-import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
 
@@ -53,7 +53,7 @@ class FeedbackFragment : Fragment(), View.OnClickListener {
                     return
                 }
 
-                val account = GoogleSignIn.getLastSignedInAccount(requireActivity())
+                val account = FirebaseAuth.getInstance().currentUser
                 val userId = account?.email ?: "defaultUserId"
 
                 val ratingMap = HashMap<String, Any>()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ play-services-auth = "21.2.0"
 google-services = "4.4.2"
 picasso = "2.71828"
 firebaseDatabaseKtx = "21.0.0"
+credentials = "1.3.0"
+googleid = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +36,9 @@ firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx",
 play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "play-services-auth" }
 picasso = { group = "com.squareup.picasso", name = "picasso", version.ref = "picasso"}
 firebase-database-ktx = { group = "com.google.firebase", name = "firebase-database-ktx", version.ref = "firebaseDatabaseKtx" }
+credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+credentials-play-services = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
+googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ androidx_core_splashscreen = "1.0.1"
 circleimageview = "3.1.0"
 firebase-bom = "33.4.0"
 firebase-auth-ktx = "23.0.0"
-play-services-auth = "21.2.0"
 google-services = "4.4.2"
 picasso = "2.71828"
 firebaseDatabaseKtx = "21.0.0"
@@ -33,7 +32,6 @@ core-splashscreen = { group = "androidx.core", name = "core-splashscreen", versi
 circleimageview = { group = "de.hdodenhof", name = "circleimageview", version.ref = "circleimageview" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebase-auth-ktx" }
-play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "play-services-auth" }
 picasso = { group = "com.squareup.picasso", name = "picasso", version.ref = "picasso"}
 firebase-database-ktx = { group = "com.google.firebase", name = "firebase-database-ktx", version.ref = "firebaseDatabaseKtx" }
 credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }


### PR DESCRIPTION
# Changelogs
- Removed deprecated methods
- Use Credential Manager instead of legacy approach
- Removed deprecated dependencies